### PR TITLE
Update azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
           publishTestResults: true
           testRunTitle: '$(Agent.JobName) on $(Agent.OS)'
 
-  - job: Tests_PI
+  - job: Tests_OnPrem
     pool:
       name: ${{ parameters.poolPI }}
       demands: ${{ parameters.containerDemandsPI }}


### PR DESCRIPTION
Some pipeline badges are broken because they are referencing ```Tests_OnPrem``` rather  than ```Tests_PI```